### PR TITLE
adding tombstoning so that we cache undefined values

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,10 +35,11 @@ db.getUserById('id', function (err, user) {
 
 ```js
 {
-  max    : 10000,
-  maxAge : ms('1m'),
-  stale  : false,
-  peek   : true // peek by default so maxAge is honored.
+  max: 10000,
+  maxAge: ms('1m'),
+  stale: false,
+  peek: true, // peek by default so maxAge is honored
+  tombstone: true // save undefined values returned as well
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,15 +4,13 @@ var clone = require('clone');
 var defaults = require('defaults');
 var LRU = require('lru-cache');
 var ms = require('ms');
-var nextTick = process.nextTick;
-
+var tick = setImmediate || process.nextTick;
 
 /**
  * Expose `ProxyCache`.
  */
 
 module.exports = ProxyCache;
-
 
 /**
  * A proxying cache.
@@ -24,6 +22,7 @@ module.exports = ProxyCache;
  *  @param {Number} maxAge
  *  @param {Boolean} stale
  *  @param {Boolean} peek
+ *  @param {Boolean} tombstone  cache undefined values as well
  */
 
 function ProxyCache (instance, methods, options) {
@@ -32,10 +31,11 @@ function ProxyCache (instance, methods, options) {
   if (!(methods instanceof Array)) throw new TypeError('Methods must be an array.');
 
   this.options = defaults(options, {
-    max    : 10000,
-    maxAge : ms('1m'),
-    stale  : false,
-    peek   : true // peek by default so maxAge is honored.
+    max: 10000,
+    maxAge: ms('1m'),
+    stale: false,
+    peek: true, // peek by default so maxAge is honored.
+    tombstone: true
   });
 
   this.parent = instance;
@@ -47,7 +47,6 @@ function ProxyCache (instance, methods, options) {
     this[method] = this._wrap(instance, method);
   }
 }
-
 
 /**
  * Proxy the instance's `key` property to this cache.
@@ -77,23 +76,26 @@ ProxyCache.prototype._proxy = function (instance, key) {
 ProxyCache.prototype._wrap = function (instance, method) {
   if (typeof instance[method] !== 'function') throw new TypeError('Can only cache methods!');
   var self = this;
+  var tombstone = this.options.tombstone;
   return function () {
     var callback = arguments[arguments.length - 1];
     var args = [].slice.call(arguments, 0, arguments.length-1);
     var key = self._key(method, args);
-    var cached = self._get(key);
-    if (cached) return nextTick(function () { callback(null, cached); });
+    if (self._has(key)) {
+      var cached = self._get(key);
+      return tick(function(){ callback(null, cached); });
+    };
     // we didn't find it in the cache, let's push our wrapped
     args.push(function (err, result) {
-      if (err || !result) return callback(err);
-      self.cache.set(key, result);
+      if (err) return callback(err);
+      var present = result != undefined;
+      if (present || tombstone) self.cache.set(key, result);
       callback(null, result);
     });
     // proxy the query to the instance
     return instance[method].apply(instance, args);
   };
 };
-
 
 /**
  * Generate a cache key.
@@ -106,7 +108,6 @@ ProxyCache.prototype._key = function (method, args) {
   return [method].concat(args).join(':');
 };
 
-
 /**
  * Get or peek into the cache with the provided `key`.
  * @param  {key} type
@@ -117,3 +118,15 @@ ProxyCache.prototype._get = function (key) {
   var get = this.options.peek ? this.cache.peek : this.cache.get;
   return clone(get(key));
 };
+
+/**
+ * See whether we have `key` in our cache.
+ * @param  {key} type
+ * @returns {Object}
+ */
+
+ProxyCache.prototype._has = function (key) {
+  return this.cache.has(key);
+};
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,6 @@ DB.prototype.getById = function (id, callback) {
   return callback(null, this.db[id]);
 };
 
-
 DB.prototype.getByType = function (type, id, callback) {
   this.queries += 1;
   return callback(null, this.db[id]);
@@ -113,6 +112,22 @@ describe('proxy-cache', function () {
       });
       async = true;
     });
+  });
 
+
+  it('should cache empty entries', function (done) {
+    var db = cache(new DB(), ['getById']);
+    var id = 'non-existant';
+    db.getById(id, function (err, result) {
+      assert(!err);
+      assert.equal(result, undefined);
+      assert.equal(db.parent.queries, 1);
+      db.getById(id, function (err, result) {
+        assert(!err);
+        assert.equal(result, undefined);
+        assert.equal(db.parent.queries, 1);     
+        done()
+      })
+    })
   });
 });


### PR DESCRIPTION
Previously, if a value wasn't found we'd query for it again. This
adds a setting so that we actually store the empty value within the
cache.